### PR TITLE
Set 'SameSite=lax' cookie attribute

### DIFF
--- a/src/stick-to-me.js
+++ b/src/stick-to-me.js
@@ -165,7 +165,7 @@
                                         if (settings.cookie == true)
                                         {
                                             cookiehowm++;
-                                            document.cookie="ck_stick_visit="+cookiehowm+"; path=/";
+                                            document.cookie="ck_stick_visit="+cookiehowm+"; path=/; SameSite=lax";
                                         }
                                         lasttime = new Date().getTime();
                                     }


### PR DESCRIPTION
To meet modern browser standards (see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite)